### PR TITLE
(fix) Syntax error in mem_reservation

### DIFF
--- a/tyk/compose.yaml
+++ b/tyk/compose.yaml
@@ -7,4 +7,4 @@ services:
 
   redis:
     image: redis:latest
-    mem_reservation: 512M
+    mem_reservation: 512


### PR DESCRIPTION
`mem_reservation` was set to `512M`, which is a `string`.  
However, the corresponding API key `memory_mb` accepts only `int`.  
That leads to the following error when running `kraft cloud compose up`:
```bash
Value of 'memory_mb' must be in the range 16 to 2048
```