### PR TITLE
fix(examples): Fix labels for non-working applications

### DIFF
--- a/llama2/Kraftfile
+++ b/llama2/Kraftfile
@@ -3,7 +3,7 @@ spec: v0.6
 runtime: llama2:latest
 
 labels:
-  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "off"
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 

--- a/minio/Kraftfile
+++ b/minio/Kraftfile
@@ -3,7 +3,7 @@ spec: v0.6
 runtime: minio:latest
 
 labels:
-  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "off"
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 

--- a/spin-wagi-http/Kraftfile
+++ b/spin-wagi-http/Kraftfile
@@ -3,7 +3,7 @@ spec: v0.6
 runtime: spin:latest
 
 labels:
-  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "off"
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 

--- a/tyk/Kraftfile
+++ b/tyk/Kraftfile
@@ -3,7 +3,7 @@ spec: v0.6
 runtime: tyk:latest
 
 labels:
-  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "off"
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 


### PR DESCRIPTION
For application that have issues, disable scale-to-zero via the `labels` attribute in `Kraftfile`.