### PR TITLE
fix(examples): Use Unikraft Cloud instead of KraftCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Unikraft Cloud Examples and Sample Projects
 
-This repository contains examples of how to deploy applications onto
-[Unikraft Cloud](https://unikraft.cloud).
+This repository contains examples of how to deploy applications onto [Unikraft Cloud](https://unikraft.cloud).
 

--- a/bun/README.md
+++ b/bun/README.md
@@ -2,7 +2,7 @@
 
 [Bun](https://bun.sh/) is an all-in-one toolkit for JavaScript and TypeScript apps.
 
-To run Bun on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Bun on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -14,5 +14,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Bun's Documentation](https://bun.sh/docs)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -2,7 +2,7 @@
 
 [Caddy](https://caddyserver.com/) is a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go.
 
-To run Caddy on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Caddy on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Caddy's Documentation](https://caddyserver.com/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/dragonflydb/README.md
+++ b/dragonflydb/README.md
@@ -2,7 +2,7 @@
 
 [DragonflyDB](https://www.dragonflydb.io/) is a simple, performant, and cost-efficient in-memory data store.
 
-To run DragonflyDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run DragonflyDB on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -14,5 +14,5 @@ After deploying, you can use `redis-cli` to query the service using the provided
 ## Learn more
 
 - [DragonflyDBS's Documentation](https://www.dragonflydb.io/docs)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/duckdb-go/README.md
+++ b/duckdb-go/README.md
@@ -2,7 +2,7 @@
 
 [DuckDB](https://duckdb.org) is an in-process SQL OLAP database management system, in your Go project.
 
-To run DuckDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run DuckDB on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [DuckDB's Go driver](https://duckdb.org/docs/api/go)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/ferretdb/README.md
+++ b/ferretdb/README.md
@@ -2,7 +2,7 @@
 
 [FerretDB](https://www.ferretdb.com/) is an open-source proxy that translates MongoDB wire protocol queries to SQL.
 
-To run FerretDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run FerretDB on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 
 To deploy it, you need to deploy a [PostgreSQL instance](https://github.com/kraftcloud/examples/tree/main/postgres16.2) using the `examples` repository:
 
@@ -42,5 +42,5 @@ kill -9 <PID>
 ## Learn more
 
 - [FerretDB's Documentation](https://docs.ferretdb.io/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -2,7 +2,7 @@
 
 [Grafana](https://grafana.com) is the open source analytics & monitoring solution for every database.
 
-To run Grafana on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Grafana on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -14,5 +14,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Grafana's Documentation](https://grafana.com/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -2,7 +2,7 @@
 
 [HAProxy](https://www.haproxy.org) is a free and open source software that provides a high availability load balancer and reverse proxy for TCP and HTTP-based applications that spreads requests across multiple servers.
 
-To run HAProxy on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run HAProxy on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -14,5 +14,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [HAProxy's Documentation](https://docs.haproxy.org/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-c/README.md
+++ b/http-c/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the C programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -15,5 +15,5 @@ After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-cpp-boost/README.md
+++ b/http-cpp-boost/README.md
@@ -2,7 +2,7 @@
 
 [Boost](https://www.boost.org/doc/) is a set of libraries for the C++ programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Boost's Documentation](https://www.boost.org/doc/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-cpp/README.md
+++ b/http-cpp/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the C++ programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -15,5 +15,5 @@ After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-dotnet8.0/README.md
+++ b/http-dotnet8.0/README.md
@@ -1,8 +1,8 @@
-# .NET on KraftCloud
+# .NET on Unikraft Cloud
 
 To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 
-To deploy this application on KraftCloud, invoke:
+To deploy this application on Unikraft Cloud, invoke:
 
 ```console
 kraft cloud deploy -p 443:8080 -M 512 .
@@ -10,5 +10,5 @@ kraft cloud deploy -p 443:8080 -M 512 .
 
 ## Learn more
 
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-elixir1.16/README.md
+++ b/http-elixir1.16/README.md
@@ -7,7 +7,7 @@ The initial contents of this example were created by using the command:
 mix new --app server . --sup
 ```
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -20,5 +20,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Elixir's Documentation](https://elixir-lang.org/docs.html)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-erlang26.2/README.md
+++ b/http-erlang26.2/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the Erlang programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Erlang's Documentation](https://www.erlang.org/doc/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-go1.21/README.md
+++ b/http-go1.21/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the [Go](https://go.dev/) programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Go's Documentation](https://go.dev/doc/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-go1.22-redis/README.md
+++ b/http-go1.22-redis/README.md
@@ -1,9 +1,9 @@
-# Go 1.21 with Redis deployed with a `Composefile` on KraftCloud
+# Go 1.21 with Redis deployed with a `Composefile` on Unikraft Cloud
 
 This is a simple HTTP server written in the [Go](https://go.dev/) programming language and uses Redis via the [Go redis module](github.com/redis/go-redis) to share keys and their values.
 The project can be instantiated using the accompanying `Composefile`.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```
@@ -33,5 +33,5 @@ curl https://<FQDN>/\?key\=my-key
 ## Learn more
 
 - [Go's Documentation](https://go.dev/doc/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-java17/README.md
+++ b/http-java17/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the [Java](https://www.java.com/en/) programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Java's Documentation](https://docs.oracle.com/en/java/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-lua5.1/README.md
+++ b/http-lua5.1/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the [Lua](https://www.lua.org/) programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Lua's Documentation](https://www.lua.org/docs.html)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-node21/README.md
+++ b/http-node21/README.md
@@ -2,7 +2,7 @@
 
 [Node,js](https://nodejs.org) is a free, open-source, cross-platform JavaScript runtime environment.
 
-To run Node.js on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Node.js on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Node.js's Documentation](https://nodejs.org/docs/latest/api/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-perl5.38/README.md
+++ b/http-perl5.38/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the [Perl](https://www.perl.org/) programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Perl's Documentation](https://www.perl.org/docs.html)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-php8.2/README.md
+++ b/http-php8.2/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the [PHP](https://www.php.net/) programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [PHP's Documentation](https://www.php.net/docs.php)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-python3.12-django5.0/README.md
+++ b/http-python3.12-django5.0/README.md
@@ -2,7 +2,7 @@
 
 [Django](https://www.djangoproject.com/) is a high-level Python web framework that encourages rapid development and clean, pragmatic design.
 
-To run Django on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Django on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -21,5 +21,5 @@ For a production site read the deployment guides of the Django project carefully
 ## Learn more
 
 - [Django's Documentation](https://docs.djangoproject.com/en/5.0/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-python3.12-flask3.0/README.md
+++ b/http-python3.12-flask3.0/README.md
@@ -2,7 +2,7 @@
 
 [Flask](https://flask.palletsprojects.com/en/3.0.x/) is a micro web framework written in Python.
 
-To run Flask on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Flask on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Flask's Documentation](https://flask.palletsprojects.com/en/3.0.x/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-python3.12/README.md
+++ b/http-python3.12/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the [Python](https://www.python.org/) programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Python's Documentation](https://www.python.org/doc/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-ruby3.2/README.md
+++ b/http-ruby3.2/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the [Ruby](https://www.ruby-lang.org/) programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Ruby's Documentation](https://www.ruby-lang.org/en/documentation/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-rust1.73/README.md
+++ b/http-rust1.73/README.md
@@ -2,7 +2,7 @@
 
 This is a simple HTTP server written in the [Rust](https://www.rust-lang.org/) programming language.
 
-To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Rust's Documentation](https://www.rust-lang.org/learn)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-rust1.75-actix-web4/README.md
+++ b/http-rust1.75-actix-web4/README.md
@@ -2,7 +2,7 @@
 
 [Actix Web](https://actix.rs/) is a powerful, pragmatic, and extremely fast web framework for Rust.
 
-To run Actix Web on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Actix Web on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Actix's Documentation](https://actix.rs/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-rust1.75-rocket0.5/README.md
+++ b/http-rust1.75-rocket0.5/README.md
@@ -2,7 +2,7 @@
 
 [Rocket](https://rocket.rs/) is web framework for Rust that makes it simple to write fast, type-safe, secure web applications.
 
-To run Rocket on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Rocket on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -17,5 +17,5 @@ See more in the `src/main.rs` source code file.
 ## Learn more
 
 - [Rockets's Documentation](https://api.rocket.rs/v0.5/rocket/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-rust1.75-tokio/README.md
+++ b/http-rust1.75-tokio/README.md
@@ -2,7 +2,7 @@
 
 [Tokio](https://tokio.rs/) is a runtime for writing reliable asynchronous applications with Rust.
 
-To run Tokio on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Tokio on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Tokios's Documentation](https://docs.rs/tokio/latest/tokio/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/hugo/README.md
+++ b/hugo/README.md
@@ -2,7 +2,7 @@
 
 [Hugo](https://gohugo.io/) is one of the most popular open-source static site generators.
 
-To run Hugo on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Hugo on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Hugo's Documentation](https://gohugo.io/documentation/).
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/imaginary/README.md
+++ b/imaginary/README.md
@@ -2,7 +2,7 @@
 
 [Imaginary](https://github.com/h2non/imaginary) is a fast, simple, scalable, Docker-ready HTTP microservice for high-level image processing.
 
-To run Imaginary on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Imaginary on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -14,5 +14,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Imaginary's Documentation](https://fly.io/docs/app-guides/run-a-global-image-service/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/java17-spring-petclinic/README.md
+++ b/java17-spring-petclinic/README.md
@@ -2,7 +2,7 @@
 
 [Spring PetClinic](https://github.com/spring-projects/spring-petclinic) is an example project that uses Spring boot to model a simple pet clinic.
 
-To run PetClinic on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run PetClinic on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -14,5 +14,5 @@ After deploying, point your browser to the provided URL.
 ## Learn more
 
 - [Spring Boot Reference](https://docs.spring.io/spring-boot/docs/current/reference/html/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/java17-springboot3.2.x/README.md
+++ b/java17-springboot3.2.x/README.md
@@ -2,7 +2,7 @@
 
 [Spring Boot](https://spring.io/projects/spring-boot) is an extension of the Spring plaform for Java that simplifies the creation of Spring applicaitons.
 
-To run SpringBoot on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run SpringBoot on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Spring Boot Reference](https://docs.spring.io/spring-boot/docs/current/reference/html/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/llama2/README.md
+++ b/llama2/README.md
@@ -2,7 +2,7 @@
 
 [Llama2.c](https://github.com/karpathy/llama2.c) is Llama2 inference in one file of pure C.
 
-To run LLama2.c on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run LLama2.c on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -18,5 +18,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Llama2.c's Documentation](https://github.com/karpathy/llama2.c/blob/master/README.md)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -2,7 +2,7 @@
 
 [MariaDB](https://mariadb.org/) is one of the most popular open source relational databases.
 
-To run MariaDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run MariaDB on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -30,5 +30,5 @@ kill -9 <PID>
 ## Learn more
 
 - [MariaDB's Documentation](https://mariadb.org/documentation/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -2,7 +2,7 @@
 
 [Memcached](https://memcached.org) is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 
-To run Memcached on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Memcached on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -36,5 +36,5 @@ kill -9 <PID>
 ## Learn more
 
 - [Memcached's Documentation](https://github.com/memcached/memcached/wiki)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/minio/README.md
+++ b/minio/README.md
@@ -2,7 +2,7 @@
 
 [MinIO](https://min.io/) is a High-Performance Object Storage system.
 
-To run MinIO on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run MinIO on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -14,5 +14,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [MinIO's Documentation](https://min.io/docs/minio/kubernetes/upstream/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -2,7 +2,7 @@
 
 [MongoDB](https://www.mongodb.com) is a source-available, cross-platform, document-oriented database program.
 
-To run MongoDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run MongoDB on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -30,5 +30,5 @@ kill -9 <PID>
 ## Learn more
 
 - [MongoDB's Documentation](https://www.mongodb.com/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -2,7 +2,7 @@
 
 [NGINX](https://www.nginx.com/) is a web server that can also be used as a reverse proxy, load balancer, mail proxy and HTTP cache.
 
-To run NGINX on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run NGINX on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [NGINX's Documentation](https://nginx.org/en/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node-express-puppeteer/README.md
+++ b/node-express-puppeteer/README.md
@@ -2,7 +2,7 @@
 
 [Puppeteer](https://pptr.dev/) is a Node.js library which provides a high-level API to control browsers, including the option to run them headless (no UI).
 
-To run Puppeteer on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Puppeteer on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -20,5 +20,5 @@ And then use the interface to generate PDF files.
 ## Learn more
 
 - [Puppeteer's Documentation](is a Node.js library which provides a high-level API to control)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node18-prisma-rest-express/README.md
+++ b/node18-prisma-rest-express/README.md
@@ -1,6 +1,6 @@
 # Node 18 Prisma
 
-This example is derived from [Prisma's REST API Example](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express) and shows how to implement a **REST API** using [Express](https://expressjs.com/) and [Prisma Client](https://www.prisma.io/docs/concepts/components/prisma-client) and deploy it onto KraftCloud.
+This example is derived from [Prisma's REST API Example](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express) and shows how to implement a **REST API** using [Express](https://expressjs.com/) and [Prisma Client](https://www.prisma.io/docs/concepts/components/prisma-client) and deploy it onto Unikraft Cloud.
 It uses a SQLite database file with some initial dummy data which you can find at [`./prisma/store.db`](./prisma/store.db).
 
 ## Getting started
@@ -38,9 +38,9 @@ You can send the API requests implemented in `index.js`, e.g.
 [`http://localhost:3000/feed`](http://localhost:3000/feed).
 
 
-### 3. Deploy to KraftCloud
+### 3. Deploy to Unikraft Cloud
 
-To deploy this project onto KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To deploy this project onto Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -319,8 +319,8 @@ datasource db {
 
 ## Next steps
 
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
 - [Prisma's Documentation docs](https://www.prisma.io/docs)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-expressjs/README.md
+++ b/node21-expressjs/README.md
@@ -2,7 +2,7 @@
 
 [Express](https://expressjs.com/) is a fast, unopinionated, minimalist web framework for Node.js.
 
-To run Express on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Express on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Express's Documentation](https://expressjs.com/en/5x/api.html)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-nextjs/README.md
+++ b/node21-nextjs/README.md
@@ -2,7 +2,7 @@
 
 [NextJS](https://nextjs.org/) enables you to create high-quality web applications with the power of React components.
 
-To run NextJS on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run NextJS on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [NextJS's Documentation](https://nextjs.org/docs)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-remix/README.md
+++ b/node21-remix/README.md
@@ -2,7 +2,7 @@
 
 [Remix](https://remix.run/)  is a full stack web framework that lets you focus on the user interface and work back through web standards to deliver a fast, slick, and resilient user experience.
 
-To run Remix on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Remix on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Remix's Documentation](https://remix.run/docs/en/main)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-solid-start/README.md
+++ b/node21-solid-start/README.md
@@ -2,7 +2,7 @@
 
 [Solid Start](https://start.solidjs.com/) a meta-framework that provides the platform to put all of web-related pieces together in a one location.
 
-To run Solid Start on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Solid Start on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Solid Starts's Documentation](https://start.solidjs.com/getting-started/what-is-solidstart)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-sveltekit/README.md
+++ b/node21-sveltekit/README.md
@@ -2,9 +2,9 @@
 
 [SvelteKit](https://kit.svelte.dev/) is built on Svelte, a UI framework that uses a compiler to let you write breathtakingly concise components that do minimal work in the browser.
 
-This project was generated using [`npm create svelte@latest`](https://kit.svelte.dev/docs/creating-a-project), uses the [`@sveltejs/adapter-node`](https://kit.svelte.dev/docs/adapter-node) adapter and includes a `Kraftfile` and `Dockerfile` to run on KraftCloud.
+This project was generated using [`npm create svelte@latest`](https://kit.svelte.dev/docs/creating-a-project), uses the [`@sveltejs/adapter-node`](https://kit.svelte.dev/docs/adapter-node) adapter and includes a `Kraftfile` and `Dockerfile` to run on Unikraft Cloud.
 
-To run SvelteKit on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run SvelteKit on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -18,5 +18,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [SvelteKit's Documentation](https://kit.svelte.dev/docs/introduction)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/opentelemetry-collector/README.md
+++ b/opentelemetry-collector/README.md
@@ -2,7 +2,7 @@
 
 [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) offers a vendor-agnostic implementation of how to receive, process and export telemetry data.
 
-To run OpenTelemetry Collector on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run OpenTelemetry Collector on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -25,5 +25,5 @@ service:
 ## Learn more
 
 - [OpenTelemetry Collectors Documentation](https://opentelemetry.io/docs/collector/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -2,7 +2,7 @@
 
 [PostgreSQL](https://www.postgresql.org/) is a powerful, open source object-relational database system.
 
-To run PostgreSQL on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run PostgreSQL on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -58,5 +58,5 @@ See an example on that in the [FerretDB documentation](../ferretdb/README.md).
 ## Learn more
 
 - [PostgreSQL's Documentation](https://www.postgresql.org/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/python3.12-flask3.0-sqlite/README.md
+++ b/python3.12-flask3.0-sqlite/README.md
@@ -2,7 +2,7 @@
 
 [Flask](https://flask.palletsprojects.com/en/3.0.x/) is a micro web framework written in Python.
 
-To run Flask on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Flask on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Flask's Documentation](https://flask.palletsprojects.com/en/3.0.x/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/redis/README.md
+++ b/redis/README.md
@@ -2,7 +2,7 @@
 
 [Redis](https://redis.io) is an open-source in-memory storage, used as a distributed, in-memory key–value database, cache and message broker, with optional durability.
 
-To run Redis on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Redis on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -30,5 +30,5 @@ kill -9 <PID>
 ## Learn more
 
 - [Redis's Documentation](https://redis.io/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/ruby3.2-rails/README.md
+++ b/ruby3.2-rails/README.md
@@ -2,7 +2,7 @@
 
 [Rails](https://rubyonrails.org/) is a server-side web application framework written in Ruby.
 
-To run Rails on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Rails on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -17,5 +17,5 @@ Use the `/hello` path for the provided URL.
 ## Learn more
 
 - [Rails's Documentation](https://guides.rubyonrails.org/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/skipper/README.md
+++ b/skipper/README.md
@@ -1,8 +1,8 @@
-# Skipper on KraftCloud
+# Skipper on Unikraft Cloud
 
 [Skipper](https://opensource.zalando.com/skipper/) is an HTTP router and reverse proxy for service composition.
 
-To run Skipper on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Skipper on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -16,5 +16,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Skipper's Documentation](https://opensource.zalando.com/skipper/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/spin-wagi-http/README.md
+++ b/spin-wagi-http/README.md
@@ -1,8 +1,8 @@
 # Spin Wagi HTTP example
 
-This example is derived from [Spin's `spin-wagi-http` example](https://github.com/fermyon/spin/tree/v2.1.0/examples/spin-wagi-http) and shows how to run a Spin application serving routes from two programs written in different languages (Rust and C++) using both the Spin executor and the Wagi executor on KraftCloud.
+This example is derived from [Spin's `spin-wagi-http` example](https://github.com/fermyon/spin/tree/v2.1.0/examples/spin-wagi-http) and shows how to run a Spin application serving routes from two programs written in different languages (Rust and C++) using both the Spin executor and the Wagi executor on Unikraft Cloud.
 
-To run Spin Wagi on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Spin Wagi on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -17,5 +17,5 @@ Use the `/hello` and `/goodbye` paths for the URL.
 ## Learn more
 
 - [Spin's Documentation](https://developer.fermyon.com/spin/v2/index)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -1,8 +1,8 @@
-# Traefik on KraftCloud
+# Traefik on Unikraft Cloud
 
 [Traefik](https://traefik.io/traefik/) is the leading open-source reverse proxy and load balancer for HTTP and TCP-based applications.
 
-To run Traefik on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Traefik on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -19,5 +19,5 @@ Use the `/dashboard` path for the URL.
 ## Learn more
 
 - [Traefik's Documentation](https://doc.traefik.io/traefik/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/tyk/README.md
+++ b/tyk/README.md
@@ -2,7 +2,7 @@
 
 [Tyk](https://tyk.io/) is an API gateway and management platform.
 
-To run Tyk on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Tyk on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -22,5 +22,5 @@ curl https://<NAME>.<METRO>.kraft.host/hello
 ## Learn more
 
 - [Tyk's Documentation](https://tyk.io/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/wazero-import-go/README.md
+++ b/wazero-import-go/README.md
@@ -1,9 +1,9 @@
 # WASM (Wazero) on Go
 
-This example is derived from [Wazero's "import go" example](https://github.com/tetratelabs/wazero/tree/main/examples/import-go) and shows how to define, import and call a wasm blob from Go and run it on KraftCloud.
+This example is derived from [Wazero's "import go" example](https://github.com/tetratelabs/wazero/tree/main/examples/import-go) and shows how to define, import and call a wasm blob from Go and run it on Unikraft Cloud.
 In the example, if the current year is 2024, and we give the argument 2000, [age-calculator.go](age-calculator.go) should output 24.
 
-To run Wazero on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Wazero on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
@@ -15,5 +15,5 @@ After deploying, you can query the service using the provided URL.
 ## Learn more
 
 - [Wazero's Documentation](https://wazero.io/docs/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/wordpress-all-in-one/README.md
+++ b/wordpress-all-in-one/README.md
@@ -2,7 +2,7 @@
 
 [Wordpress](https://wordpress.com/) is a web content management system.
 
-To run Wordpress on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Wordpress on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 
 This Wordpress builds connects together three types of services:
 
@@ -22,5 +22,5 @@ It will show you an install screen for Wordpress.
 ## Learn more
 
 - [Wordpress's Documentation](https://wordpress.org/documentation/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -2,9 +2,9 @@
 
 [Wordpress](https://wordpress.com/) is a web content management system.
 
-To run Wordpress on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+To run Wordpress on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
 
-Wordpress requires connecting three KraftCloud instances:
+Wordpress requires connecting three Unikraft Cloud instances:
 
 * A MariaDB database instance
 * A Wordress instance, using PHP FPM (*FastCGI Process Manager*)
@@ -19,7 +19,7 @@ Create a MariaDB instance and assign it the `mariadb` name:
 kraft cloud deploy --metro fra0 --name mariadb -p 3306:3306/tls -M 1024 mariadb:latest
 ```
 
-The MariaDB instance can be referenced by other KraftCloud instances as `mariadb.internal`.
+The MariaDB instance can be referenced by other Unikraft Cloud instances as `mariadb.internal`.
 
 After deploying, you can query the service using the provided URL.
 For that, first use `socat` to open a TLS connection to port `3306` (MariaDB's listening port):
@@ -58,7 +58,7 @@ kraft cloud deploy -e WORDPRESS_DB_HOST="mariadb.internal" -e WORDPRESS_DB_NAME=
 
 This will create a Wordress instance using PHP FPM (*FastCGI Process Manager*).
 We use the `mariadb.internal` name to connect to the MariaDB instance started above.
-The Wordpress instance can be referenced by other KraftCloud instances as `wordpress.internal`.
+The Wordpress instance can be referenced by other Unikraft Cloud instances as `wordpress.internal`.
 
 ## Set Up Nginx
 
@@ -171,5 +171,5 @@ It will show you an install screen for Wordpress.
 ## Learn more
 
 - [Wordpress's Documentation](https://wordpress.org/documentation/)
-- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
 - [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)


### PR DESCRIPTION
Use Unikraft Cloud name instead of KraftCloud in all `README.md` files. Replace `https://docs.kraft.cloud` with `https://unikraft.cloud/docs`.