### PR TITLE
http-elixir: Fix stateful cooldown

### DIFF
--- a/http-elixir1.16/Kraftfile
+++ b/http-elixir1.16/Kraftfile
@@ -7,7 +7,7 @@ runtime: base-compat:latest
 labels:
   cloud.unikraft.v1.instances/scale_to_zero.policy: "idle"
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
-  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 3000
 
 rootfs: ./Dockerfile
 


### PR DESCRIPTION
Elixir goes through a number of actions to start the network service. It requires more that `1000ms` for proper stateful start. Increase cooldown to `3000ms`.

Note that after starting an Elixir instance, several seconds are required for it to reach the final state. During that time, requests will fail. After that, queries will work as expected, in a stateful setup.