### PR TITLE
fix(examples): Use kraft.host in README files

### DIFF
--- a/ferretdb/README.md
+++ b/ferretdb/README.md
@@ -23,7 +23,7 @@ After deploying, you can query the service using the provided URL.
 For that, first use `socat` to open a TLS connection (save the returned PID):
 
 ```console
-socat tcp-listen:27017,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:27017 &
+socat tcp-listen:27017,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.host:27017 &
 ```
 
 Now you can query FerretDB using `mongosh`.

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -12,7 +12,7 @@ kraft cloud deploy --metro fra0 -p 3306:3306/tls -M 1024 .
 Get the results of the deployment by first forwarding the port (save the returned PID):
 
 ```console
-socat tcp-listen:3306,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:3306 &
+socat tcp-listen:3306,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.host:3306 &
 ```
 
 Then, run the following command to test that it works:

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -12,7 +12,7 @@ kraft cloud deploy --metro fra0 -p 11211:11211/tls -M 256 .
 Get the results of the deployment by first forwarding the port (save the returned PID):
 
 ```console
-socat tcp-listen:11211,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:11211 &
+socat tcp-listen:11211,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.host:11211 &
 ```
 
 Then, run the following commands to test that it works (you should see output when incrementing):

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -12,7 +12,7 @@ kraft cloud deploy --metro fra0 -p 27017:27017/tls -M 1024 .
 To connect, you first need to create a tunnel to the remote server (save the returned PID):
 
 ```console
-socat tcp-listen:27017,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:27017 &
+socat tcp-listen:27017,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.host:27017 &
 ```
 
 Then you can use the `mongo` client to connect to the server:

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -13,10 +13,10 @@ After deploying, you can query the service using the provided URL.
 For that, first use `socat` to open a TLS connection (save the returned PID):
 
 ```console
-socat tcp-listen:5432,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:5432 &
+socat tcp-listen:5432,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.host:5432 &
 ```
 
-where `<NAME>.<METRO>.kraft.cloud` is the name of the instance created above.
+where `<NAME>.<METRO>.kraft.host` is the name of the instance created above.
 
 Now you can query PostgreSQL using [`psql`](https://www.postgresql.org/docs/current/app-psql.html).
 We assume the username is `postgres` and the password is `unikraft`:

--- a/redis/README.md
+++ b/redis/README.md
@@ -12,7 +12,7 @@ kraft cloud deploy --metro fra0 -p 6379:6379/tls -M 512 .
 First, open a connection to the Redis server (save the pid):
 
 ```console
-socat tcp-listen:6379,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:6379 &
+socat tcp-listen:6379,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.host:6379 &
 ```
 
 Then use `redis-cli` or `redis-benchmark` to test the connection (keep in mind that `socat` will also slow down your benchmark):

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -25,7 +25,7 @@ After deploying, you can query the service using the provided URL.
 For that, first use `socat` to open a TLS connection to port `3306` (MariaDB's listening port):
 
 ```console
-socat tcp-listen:3306,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:3306 &
+socat tcp-listen:3306,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.host:3306 &
 ```
 
 Create the Wordpress database, user and password on MariaDB.


### PR DESCRIPTION
Use `<NAME>.<METRO>.kraft.host` instead of `<NAME>.<METRO>.kraft.cloud` throughout `README.md` files.