### PR TITLE
fix(examples): Increase scale-to-zero cooldown for Wordpress

### DIFF
--- a/wordpress-all-in-one/Kraftfile
+++ b/wordpress-all-in-one/Kraftfile
@@ -7,7 +7,7 @@ runtime: base-compat:latest
 labels:
   cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
-  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 3000
 
 rootfs: ./Dockerfile
 


### PR DESCRIPTION
The current scale-to-zero cooldown (`1000ms`) in insufficient to fully start the Wordpress instance. With this, the first queries fail, as the service is not fully started. Simply put, the instance goes to sleep to soon after being started and, when it is woken up by a query, it cannot serve it.

Update the scale-to-zero cooldown to `3000ms`.