### PR TITLE
fix(node21-nextjs): Increase the container memory allocation

### DIFF
--- a/node21-nextjs/README.md
+++ b/node21-nextjs/README.md
@@ -6,7 +6,7 @@ To run NextJS on Unikraft Cloud, first [install the `kraft` CLI tool](https://un
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy --metro fra0 -p 443:3000 -M 256 .
+kraft cloud deploy --metro fra0 -p 443:3000 -M 512 .
 ```
 
 The command will build the files in the current directory.


### PR DESCRIPTION
Increase the memory allocated to the container running `node21-nextjs` example.

- `README.md` Change the memory allocated