### PR TITLE
fix(workflow): Install file and grep for Playground Firefox

### DIFF
--- a/.github/workflows/example-node-playwright-firefox-stable.yaml
+++ b/.github/workflows/example-node-playwright-firefox-stable.yaml
@@ -48,6 +48,9 @@ jobs:
         run: |
           set -xe;
 
+          sudo apt-get -y update;
+          sudo apt-get install -y --no-install-recommends file grep;
+
           cd node-playwright-firefox;
 
           kraft cloud deploy \

--- a/.github/workflows/example-node-playwright-firefox-staging.yaml
+++ b/.github/workflows/example-node-playwright-firefox-staging.yaml
@@ -48,6 +48,9 @@ jobs:
         run: |
           set -xe;
 
+          sudo apt-get -y update;
+          sudo apt-get install -y --no-install-recommends file grep;
+
           cd node-playwright-firefox;
 
           kraft cloud deploy \


### PR DESCRIPTION
Install `file` and `grep` packages in GitHub workflows for Playground Firefox.