### PR TITLE
Introduce Debian SSH image

### DIFF
--- a/debian-ssh/.dockerignore
+++ b/debian-ssh/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/debian-ssh/.gitignore
+++ b/debian-ssh/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/debian-ssh/Dockerfile
+++ b/debian-ssh/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:bookworm AS build
+
+WORKDIR /src
+
+RUN set -xe; \
+    apt-get -yqq update; \
+    apt-get -yqq install openssh-server strace net-tools \
+    ;
+
+RUN echo "root:unikraft" | chpasswd
+
+RUN mkdir /run/sshd
+
+COPY ./wrapper.sh /usr/bin/wrapper.sh

--- a/debian-ssh/Kraftfile
+++ b/debian-ssh/Kraftfile
@@ -1,0 +1,12 @@
+spec: v0.6
+
+runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "off"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/wrapper.sh"]

--- a/debian-ssh/README.md
+++ b/debian-ssh/README.md
@@ -1,0 +1,27 @@
+# Debian SSH Connection
+
+This is a Debian SSH server deployed on Unikraft Cloud, as a debug interface.
+
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
+
+```console
+kraft cloud deploy --metro fra0 -M 1Gi -e PUBKEY="...." .
+```
+
+To connect to the debug console (via SSH), run the command below:
+
+```console
+kraft cloud tunnel 2222:<instance-name>:2222
+```
+
+Then connect to the instance via SSH using:
+
+```console
+ssh -l root localhost -p 2222
+```
+
+## Learn more
+
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/debian-ssh/sshd_config
+++ b/debian-ssh/sshd_config
@@ -1,0 +1,13 @@
+Include /etc/ssh/sshd_config.d/*.conf
+Port 22
+AddressFamily any
+ListenAddress 0.0.0.0
+HostKey /etc/ssh/ssh_host_ecdsa_key
+PermitRootLogin yes
+PasswordAuthentication yes
+KbdInteractiveAuthentication no
+UsePAM yes
+X11Forwarding yes
+PrintMotd no
+AcceptEnv LANG LC_*
+Subsystem	sftp	/usr/lib/openssh/sftp-server

--- a/debian-ssh/wrapper.sh
+++ b/debian-ssh/wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -ex
+
+# Start SSH server.
+export HOME=/root
+
+if test ! -z "$PUBKEY"; then
+    echo "$PUBKEY" >> /root/.ssh/authorized_keys
+fi
+
+/usr/sbin/sshd -D -h /etc/ssh/ssh_host_ecdsa_key -p 2222


### PR DESCRIPTION
Introduce simple Debian SSH image. Use `kraft cloud tunnel` to create a tunnel to the instance and then use `ssh` to connect to the instance.