### PR TITLE
feat(examples): Introduce MariaDB with volumes

### DIFF
--- a/mariadb11.7-volumes/.dockerignore
+++ b/mariadb11.7-volumes/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/mariadb11.7-volumes/.gitignore
+++ b/mariadb11.7-volumes/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/mariadb11.7-volumes/50-server.cnf
+++ b/mariadb11.7-volumes/50-server.cnf
@@ -1,0 +1,121 @@
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mariadbd daemon
+[mariadbd]
+
+#
+# * Basic Settings
+#
+
+#user                    = mysql
+pid-file                = /run/mysqld/mysqld.pid
+basedir                 = /usr
+#datadir                 = /var/lib/mysql
+#tmpdir                  = /tmp
+
+# Broken reverse DNS slows down connections considerably and name resolve is
+# safe to skip if there are no "host by domain name" access grants
+skip-name-resolve
+
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+bind-address            = 0.0.0.0
+
+# Collation
+collation-server        = utf8mb4_unicode_ci
+init-connect            = 'SET NAMES utf8mb4'
+character-set-server    = utf8mb4
+
+#
+# * Fine Tuning
+#
+
+#key_buffer_size        = 128M
+#max_allowed_packet     = 1G
+#thread_stack           = 192K
+#thread_cache_size      = 8
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+#myisam_recover_options = BACKUP
+#max_connections        = 100
+#table_cache            = 64
+
+#
+# * Logging and Replication
+#
+
+# Note: The configured log file or its directory need to be created
+# and be writable by the mysql user, e.g.:
+# $ sudo mkdir -m 2750 /var/log/mysql
+# $ sudo chown mysql /var/log/mysql
+
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# Recommend only changing this at runtime for short testing periods if needed!
+#general_log_file       = /var/log/mysql/mysql.log
+#general_log            = 1
+
+# Error logging goes via stdout/stderr, which on systemd systems goes to
+# journald.
+# Enable this if you want to have error logging into a separate file
+#log_error = /var/log/mysql/error.log
+# Enable the slow query log to see queries with especially long duration
+#log_slow_query_file    = /var/log/mysql/mariadb-slow.log
+#log_slow_query_time    = 10
+#log_slow_verbosity     = query_plan,explain
+#log-queries-not-using-indexes
+#log_slow_min_examined_row_limit = 1000
+
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replica, see README.Debian about other
+#       settings you may need to change.
+#server-id              = 1
+#log_bin                = /var/log/mysql/mysql-bin.log
+expire_logs_days        = 10
+#max_binlog_size        = 100M
+
+#
+# * SSL/TLS
+#
+
+# For documentation, please read
+# https://mariadb.com/kb/en/securing-connections-for-client-and-server/
+#ssl-ca = /etc/mysql/cacert.pem
+#ssl-cert = /etc/mysql/server-cert.pem
+#ssl-key = /etc/mysql/server-key.pem
+#require-secure-transport = on
+
+#
+# * Character sets
+#
+
+# MariaDB default is now utf8 4-byte character set.
+# No Debian specific default is required.
+
+#
+# * InnoDB
+#
+
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+# Most important is to give InnoDB 80 % of the system RAM for buffer use:
+# https://mariadb.com/kb/en/innodb-system-variables/#innodb_buffer_pool_size
+#innodb_buffer_pool_size = 8G
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadbd]
+
+# This group is only read by MariaDB-11.7 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mariadb-11.7]

--- a/mariadb11.7-volumes/Dockerfile
+++ b/mariadb11.7-volumes/Dockerfile
@@ -1,0 +1,101 @@
+FROM mariadb:11.7.2-noble AS build
+
+FROM scratch
+
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# MariaDB binary
+COPY --from=build /usr/sbin/mariadbd /usr/sbin/mariadbd
+
+# MariaDB support binaries
+COPY --from=build /usr/bin/mariadb \
+                  /usr/bin/mariadb-install-db \
+                  /usr/bin/mariadb-tzinfo-to-sql \
+                  /usr/bin/my_print_defaults \
+                  /usr/bin/
+
+# MariaDB support files
+COPY --from=build /run/mysqld /run/mysqld
+COPY --from=build /etc/mysql /etc/mysql
+COPY --from=build /usr/lib/mysql /usr/lib/mysql
+COPY --from=build /usr/share/mariadb /usr/share/mariadb
+
+# MariaDB libraries
+COPY --from=build /lib/x86_64-linux-gnu/libpcre2-8.so.0 \
+                  /lib/x86_64-linux-gnu/libcrypt.so.1 \
+                  /lib/x86_64-linux-gnu/liburing.so.2 \
+                  /lib/x86_64-linux-gnu/libsystemd.so.0 \
+                  /lib/x86_64-linux-gnu/libz.so.1 \
+                  /lib/x86_64-linux-gnu/libssl.so.3 \
+                  /lib/x86_64-linux-gnu/libcrypto.so.3 \
+                  /lib/x86_64-linux-gnu/libstdc++.so.6 \
+                  /lib/x86_64-linux-gnu/libm.so.6 \
+                  /lib/x86_64-linux-gnu/libgcc_s.so.1 \
+                  /lib/x86_64-linux-gnu/libc.so.6 \
+                  /lib/x86_64-linux-gnu/libcap.so.2 \
+                  /lib/x86_64-linux-gnu/libgcrypt.so.20 \
+                  /lib/x86_64-linux-gnu/liblz4.so.1 \
+                  /lib/x86_64-linux-gnu/liblzma.so.5 \
+                  /lib/x86_64-linux-gnu/libzstd.so.1 \
+                  /lib/x86_64-linux-gnu/libgpg-error.so.0 \
+                  /lib/x86_64-linux-gnu/libedit.so.2 \
+                  /lib/x86_64-linux-gnu/libncurses.so.6 \
+                  /lib/x86_64-linux-gnu/libtinfo.so.6 \
+                  /lib/x86_64-linux-gnu/libbsd.so.0 \
+                  /lib/x86_64-linux-gnu/libmd.so.0 \
+                  /lib/x86_64-linux-gnu/
+
+# Loader
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# User database
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/shadow /etc/shadow
+
+# Entrypoint scripts
+COPY --from=build /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --from=build /docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
+
+# Support binaries for entrypoint script
+COPY --from=build /bin/sh /bin/sh
+COPY --from=build /bin/bash /bin/bash
+COPY --from=build /usr/bin/date /usr/bin/date
+COPY --from=build /usr/bin/awk /usr/bin/awk
+COPY --from=build /usr/bin/id /usr/bin/id
+COPY --from=build /usr/bin/mkdir /usr/bin/mkdir
+COPY --from=build /usr/bin/find /usr/bin/find
+COPY --from=build /usr/bin/kill /usr/bin/kill
+COPY --from=build /usr/bin/chown /usr/bin/chown
+COPY --from=build /usr/bin/chmod /usr/bin/chmod
+COPY --from=build /usr/bin/ls /usr/bin/ls
+COPY --from=build /usr/bin/sed /usr/bin/sed
+COPY --from=build /usr/bin/uname /usr/bin/uname
+COPY --from=build /usr/bin/cat /usr/bin/cat
+COPY --from=build /usr/bin/sleep /usr/bin/sleep
+COPY --from=build /usr/bin/pwgen /usr/bin/pwgen
+COPY --from=build /usr/local/bin/gosu /usr/local/bin/gosu
+COPY --from=build /bin/mount /bin/mount
+
+# Support files
+COPY --from=build /etc/alternatives /etc/alternatives
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Libraries for support binaries
+COPY --from=build /lib/x86_64-linux-gnu/libtinfo.so.6 \
+                  /lib/x86_64-linux-gnu/libc.so.6 \
+                  /lib/x86_64-linux-gnu/libsigsegv.so.2 \
+                  /lib/x86_64-linux-gnu/libreadline.so.8 \
+                  /lib/x86_64-linux-gnu/libmpfr.so.6 \
+                  /lib/x86_64-linux-gnu/libgmp.so.10 \
+                  /lib/x86_64-linux-gnu/libm.so.6 \
+                  /lib/x86_64-linux-gnu/libselinux.so.1 \
+                  /lib/x86_64-linux-gnu/libacl.so.1 \
+                  /lib/x86_64-linux-gnu/libmount.so.1 \
+                  /lib/x86_64-linux-gnu/libblkid.so.1 \
+                  /lib/x86_64-linux-gnu/
+
+# Wrapper script
+COPY ./wrapper.sh /usr/local/bin/wrapper.sh
+
+# Mariadb configuration file
+COPY ./50-server.cnf /etc/mysql/mariadb.conf.d/50-server.cnf

--- a/mariadb11.7-volumes/Kraftfile
+++ b/mariadb11.7-volumes/Kraftfile
@@ -1,0 +1,12 @@
+spec: v0.6
+
+runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "off"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/wrapper.sh"]

--- a/mariadb11.7-volumes/README.md
+++ b/mariadb11.7-volumes/README.md
@@ -1,0 +1,39 @@
+# MariaDB with Persistence (as Volumes)
+
+[MariaDB](https://mariadb.org/) is one of the most popular open source relational databases.
+This example deploy MariaDB with persistence storage on Unikraft Cloud (UKC), using volumes.
+
+To run MariaDB on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
+
+```console
+kraft cloud volume create --name mariadb-store --size 512
+kraft cloud deploy -M 1024 --env MARIADB_ROOT_PASSWORD="unikraft" --volume mariadb-store:/var/lib .
+```
+
+Get the results of the deployment by first forwarding the port:
+
+```console
+kraft cloud tunnel <instance_name>:3306
+```
+
+where `<instance_name>` is the name of the instance returned by the `kraft cloud deploy` command, typically `mariadb117-<some_random_string_here>`.
+
+Then, on another console, run a MariaDB client.
+You can use either the `mysql` client:
+
+```console
+mysql -h 127.0.0.1 --skip-ssl -u root -punikraft mysql <<< "select count(*) from user"
+```
+
+Or you can use the `mariadb` client:
+
+```console
+mariadb -h 127.0.0.1 --ssl=OFF -u root -punikraft mysql <<< "select count(*) from user"
+```
+
+## Learn more
+
+- [MariaDB's Documentation](https://mariadb.org/documentation/)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/mariadb11.7-volumes/wrapper.sh
+++ b/mariadb11.7-volumes/wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+test -d /tmp || mkdir /tmp
+chmod 1777 /tmp
+/usr/local/bin/docker-entrypoint.sh mariadbd


### PR DESCRIPTION
Introduce a MariaDB install (11.7) that uses the `base-compat` runtime and volumes for persistence. A volume is mounted in `/var/lib` to store the database files in a persistent manner.

Add:

* `Kraftfile`: build / run rules
* `Dockerfile`: build the MariaDB filesystem
* `50-server.cnf`: MariaDB configuration
* `README.md`: document how to use
* `wrapper.sh`: wrapper start-up script for MariaDB
* `.dockerignore` / `.gitignore`: ignore generated files