### PR TITLE
fix(workflows): Bump memory for skipper

### DIFF
--- a/.github/workflows/example-skipper-staging.yaml
+++ b/.github/workflows/example-skipper-staging.yaml
@@ -52,7 +52,7 @@ jobs:
 
           kraft cloud deploy \
             --no-start \
-            --memory 256 \
+            --memory 384 \
             --name skipper-${GITHUB_RUN_ID} \
             --runtime index.unikraft.io/official-staging/skipper:0.18 \
             --subdomain skipper-${GITHUB_RUN_ID} \
@@ -89,7 +89,7 @@ jobs:
 
           kraft cloud deploy \
             --no-start \
-            --memory 256 \
+            --memory 384 \
             --name skipper-${GITHUB_RUN_ID}-dbg \
             --runtime index.unikraft.io/official-staging/skipper:0.18-dbg \
             --subdomain skipper-${GITHUB_RUN_ID}-dbg \


### PR DESCRIPTION
Similar to https://github.com/unikraft-cloud/examples/pull/186; does the same for skipper which was missed on 1st pass.