### PR TITLE
chore: Update titles/intros of examples used in use case docs

### DIFF
--- a/build-environments/README.md
+++ b/build-environments/README.md
@@ -1,10 +1,11 @@
-# Build/Test Environments with ROMs
+# Build and Test Environments with ROMs
+
+Build and test workloads need to run frequently changing code in a stable, isolated runtime, without rebuilding a full image for every change.
 
 This guide shows how to deploy a Go runtime that compiles ROM-provided code before execution.
 The base image contains a generic server and Go toolchain.
 Each ROM only contains a `rom.go` file, which the instance compiles into a Go plugin (`.so`) at startup.
-
-This pattern is useful for build and test environments where runtime code changes frequently but the execution environment stays stable.
+Because only the ROM changes between runs, you update the code under test by pushing a small ROM while the runtime stays as it is.
 
 ## Prerequisites
 

--- a/github-webhook-node/README.md
+++ b/github-webhook-node/README.md
@@ -1,7 +1,9 @@
-# GitHub Webhook receiver
+# Webhooks: GitHub Webhook Receiver
+
+Webhooks, also called reverse APIs, are how a service sends real-time data to other applications the moment a specific event occurs, instead of those applications polling for changes.
+Events arrive in bursts and are silent in between, so a receiver that scales to zero and wakes in milliseconds costs nothing while it waits.
 
 This example shows how to build a simple GitHub Webhook receiver using Node.js with [Express](https://expressjs.com/) and run it on Unikraft Cloud.
-A webhook, also called a reverse API, is a way for a server to send real-time data to other applications when a specific event occurs.
 In this case, the webhook receiver listens for GitHub events, such as push events or pull request events, and logs them to the console.
 
 To run this example, follow these steps:

--- a/httpserver-node-express-puppeteer/README.md
+++ b/httpserver-node-express-puppeteer/README.md
@@ -1,6 +1,10 @@
-# Puppeteer HTTP Server
+# Headless Browsers: Puppeteer HTTP Server
+
+Headless browsers power web scraping, automated testing, search engine optimization (SEO) rendering, screenshotting, and document generation.
+They are resource-intensive and usually run in short bursts, which makes them a good fit for instances that boot in milliseconds and scale to zero between jobs.
 
 This guide shows you how to use [Puppeteer](https://pptr.dev/), a Node.js library which provides a high-level API to control browsers, including the option to run them headless (no UI).
+The example wraps Puppeteer in an [Express](https://expressjs.com/) HTTP server that renders a URL or an HTML payload to PDF.
 
 To run it, follow these steps:
 

--- a/mcp-server-arxiv/README.md
+++ b/mcp-server-arxiv/README.md
@@ -1,4 +1,7 @@
-# ArXiv MCP Server
+# MCP Servers: ArXiv MCP Server
+
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io/docs/getting-started/intro) servers are the bridge between AI assistants and real-world resources such as file systems, databases, APIs, and search engines.
+AI interactions are bursty, so a server that scales to zero when unused and wakes in milliseconds only costs you for the queries it answers.
 
 This example demonstrates how to deploy the [ArXiv MCP server](https://github.com/blazickjp/arxiv-mcp-server) on Unikraft Cloud.
 

--- a/minecraft/README.md
+++ b/minecraft/README.md
@@ -1,4 +1,7 @@
-# Minecraft
+# Game Servers: Minecraft
+
+Game servers have expensive startup paths, loading assets and initializing world state, and long idle stretches between sessions, which usually means paying for a server that runs all day.
+Minecraft is a strong example of the pattern: JVM warm-up and world initialization happen once into a template snapshot, and an instance pauses when the last player disconnects, then resumes from that snapshot on the next connection.
 
 This example runs a Minecraft Java server on Unikraft Cloud with:
 

--- a/node-code-execution/README.md
+++ b/node-code-execution/README.md
@@ -1,4 +1,7 @@
-# Node.js Code Execution with ROMs
+# Serverless Functions: Node.js Code Execution with ROMs
+
+Serverless functions let you deploy small pieces of business logic without managing servers or runtimes.
+This example implements that model for Node.js, keeping the function code separate from the runtime image that executes it, so you update a function without rebuilding the runtime.
 
 This guide explains how to deploy TypeScript/JavaScript functions as auxiliary Read-Only Memory (ROM) images, then load them dynamically in a Node.js runtime.
 With Unikraft Cloud, you can create a base image with a generic runtime, package custom code as ROMs, and attach different ROMs to instances of the same base image.

--- a/novnc-browser/README.md
+++ b/novnc-browser/README.md
@@ -1,4 +1,7 @@
-# noVNC
+# Remote Desktops: noVNC
+
+Remote desktops put a full Linux GUI behind a browser tab, which powers agentic computer-use workloads, secure browsing sessions, and disposable workstations.
+They are memory-hungry and used in short, interactive bursts, so each desktop runs in its own instance that scales to zero between sessions.
 
 This guide explains how to create and deploy a [noVNC](https://novnc.com/info.html) app, allowing you to access remote desktops through
 a web interface inside a modern browser.

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1,4 +1,7 @@
-# OpenClaw
+# Sandboxes: OpenClaw
+
+Sandboxes are on-demand, isolated execution environments for work you would rather not run next to anything else, such as AI agent tool calls, user-submitted code, or third-party plugins.
+This example uses [OpenClaw](https://openclaw.ai/), an autonomous AI agent framework, as the sandboxed workload: the gateway and everything the agent runs stay inside a dedicated microVM, which scales to zero when idle and resumes in milliseconds.
 
 This guide explains how to create and deploy your very own OpenClaw gateway on Unikraft Cloud.
 To run this example, follow these steps:

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,6 +1,9 @@
-# PostgreSQL
+# Serverless Databases: PostgreSQL
 
-This guide shows you how to use [PostgreSQL](https://www.postgresql.org/), a powerful, open source object-relational database system.
+Serverless databases scale up the moment a query arrives and cost nothing while idle, instead of keeping a provisioned instance running around the clock.
+
+This guide shows you how to use [PostgreSQL](https://www.postgresql.org/), a powerful, open source object-relational database system, in exactly that fashion.
+The database runs in a lightweight virtual machine that scales to zero when not in use and resumes in milliseconds on the next connection.
 
 To run it, follow these steps:
 

--- a/tyk/README.md
+++ b/tyk/README.md
@@ -1,4 +1,7 @@
-# Tyk
+# API Gateways: Tyk
+
+An API gateway is the entry point to your services, handling authentication, routing, rate-limiting, and observability at the edge of your infrastructure.
+API traffic fluctuates, so a gateway that scales to zero when idle and starts in milliseconds when traffic returns keeps your API edge ready without paying for it overnight.
 
 This example uses [`Tyk`](https://tyk.io/), an API gateway and management platform.
 Tyk is used together with Redis to store API tokens and OAuth clients.

--- a/visual-studio-code-server/README.md
+++ b/visual-studio-code-server/README.md
@@ -1,4 +1,7 @@
-# Visual Studio Code Server
+# Remote IDEs: Visual Studio Code Server
+
+Remote IDEs give developers a full development environment in the cloud, reachable from a browser, which suits cloud-native development, collaboration, and education.
+Editing sessions are bursty, so an IDE that scales to zero when idle and resumes in milliseconds bills for coding time rather than for the whole day.
 
 [Visual Studio Code](https://code.visualstudio.com/) is a source-code editor developed by Microsoft.
 It includes support for debugging, syntax highlighting, intelligent code completion, snippets, code refactoring, and embedded Git.


### PR DESCRIPTION
The aim is to make it clearer how the example relates to the general use case